### PR TITLE
resolve session expiration exceptions

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,15 +3,16 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager
 from flask_socketio import SocketIO
 from flask_session import Session
-import os
-from datetime import timedelta
+# import os
+# from datetime import timedelta
 
 socketio = SocketIO(manage_session=False)
 db = SQLAlchemy()
 login_manager = LoginManager()
 sess = Session()
 
-def create_app(debug=False,redishost='localhost'):
+
+def create_app(debug=False, redishost='localhost'):
     """Create an application."""
     app = Flask(__name__)
     app.debug = debug
@@ -21,10 +22,9 @@ def create_app(debug=False,redishost='localhost'):
     app.config['SESSION_TYPE'] = 'sqlalchemy'
     app.config['SESSION_SQLALCHEMY'] = db
 #    app.config['PERMANENT_SESSION_LIFETIME'] = timedelta(minutes=5)
-    
+
     from .main import main as main_blueprint
     app.register_blueprint(main_blueprint)
-
 
     db.init_app(app)
     socketio.init_app(app)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -20,7 +20,7 @@ def create_app(debug=False,redishost='localhost'):
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     app.config['SESSION_TYPE'] = 'sqlalchemy'
     app.config['SESSION_SQLALCHEMY'] = db
-    app.config['PERMANENT_SESSION_LIFETIME'] = timedelta(minutes=5)
+#    app.config['PERMANENT_SESSION_LIFETIME'] = timedelta(minutes=5)
     
     from .main import main as main_blueprint
     app.register_blueprint(main_blueprint)

--- a/app/main/events.py
+++ b/app/main/events.py
@@ -1,22 +1,25 @@
 import functools
-from flask import session, current_app, request, redirect, url_for
+from flask import session, request
 from flask_login import current_user
 import flask_login
-from flask_socketio import emit, join_room, leave_room, disconnect
+from flask_socketio import emit, join_room, leave_room
 from .. import socketio, login_manager
 from ..models import db, room_members
 
 # expire a room key after X seconds of being idle
 room_idle_max = 1200
 
+
 class User(flask_login.UserMixin):
     pass
+
 
 def authenticated_only(f):
     @functools.wraps(f)
     def wrapped(*args, **kwargs):
         if not current_user.is_authenticated:
-            print("User {} is not authenticated, disconnecting".format(current_user))
+            print(("User {} is not authenticated, "
+                   "disconnecting").format(current_user))
 #            disconnect()
             room = session.get('room')
             leave_room(room)
@@ -24,11 +27,13 @@ def authenticated_only(f):
             return f(*args, **kwargs)
     return wrapped
 
+
 @login_manager.user_loader
 def load_user(user_id):
     user = User()
     user.id = user_id
     return user
+
 
 @socketio.on('joined', namespace='/chat')
 def joined(message):
@@ -38,21 +43,28 @@ def joined(message):
     update_room_idle(room)
     name = session.get('name')
 #    sid = request.cookies.get(app.session_cookie_name)
-    print("Room {} - Name {}".format(room,name))
+    print("Room {} - Name {}".format(room, name))
     sid = session.sid
     print("Sessionid {}".format(sid))
     join_room(room)
 
     emit('status', {'msg': name + ' has entered the room.'}, room=room)
     # Sample message sent to just to the user who logged in
-    emit('message', {'msg': "Hello " + name + " thanks for joining %s" % (request.sid)}, room = request.sid)
+    emit('message',
+         {'msg': "Hello " + name + " thanks for joining %s" % (request.sid)},
+         room=request.sid)
 
     # add the user to the user list in sqlite
-    query = room_members(room = room, member_id = sid, member_name = name, spectator = True, dm_room = request.sid)
+    query = room_members(room=room,
+                         member_id=sid,
+                         member_name=name,
+                         spectator=True,
+                         dm_room=request.sid)
     db.session.add(query)
     db.session.commit()
-    #update_observer_status(room,sid)
+    # update_observer_status(room,sid)
     send_userlist(room)
+
 
 @socketio.on('text', namespace='/chat')
 @authenticated_only
@@ -61,9 +73,12 @@ def text(message):
     The message is sent to all people in the room."""
     room = session.get('room')
     update_room_idle(room)
-    emit('message', {'msg': session.get('name') + ':' + message['msg']}, room=room)
+    emit('message',
+         {'msg': session.get('name') + ':' + message['msg']},
+         room=room)
 
-#@socketio.on('disconnect', namespace='/chat')
+
+# @socketio.on('disconnect', namespace='/chat')
 @socketio.on('left', namespace='/chat')
 def left(message):
     """Sent by clients when they leave a room.
@@ -75,9 +90,10 @@ def left(message):
     emit('status', {'msg': name + ' has left the room.'}, room=room)
 
     # remove the user to the user list in sqlite
-    db.session.query(room_members).filter_by(room = room, member_id = sid).delete()
+    db.session.query(room_members).filter_by(room=room, member_id=sid).delete()
     db.session.commit()
     send_userlist(room)
+
 
 @socketio.on("observer", namespace="/chat")
 @authenticated_only
@@ -85,18 +101,26 @@ def checkObserver(message):
     room = session.get('room')
     name = session.get('name')
     sid = session.sid
-    listtmp = db.session.query(room_members.spectator).filter_by(room=room, member_id=sid).all()
+    listtmp = (db.session.query(room_members.spectator)
+               .filter_by(room=room, member_id=sid).all())
     spec = [value for value, in listtmp]
     new_spec = None
     if spec[0] is True:
         new_spec = False
     else:
         new_spec = True
-    print("User {} wants to toggle their observer status from {} to {}".format(name,spec[0],new_spec))
-    db.session.query(room_members).filter_by(room=room, member_id=sid).update({room_members.spectator: new_spec})
+    print(("User {} wants to toggle "
+          "their observer status "
+           "from {} to {}").format(name, spec[0], new_spec))
+    (
+        db.session.query(room_members)
+        .filter_by(room=room, member_id=sid)
+        .update({room_members.spectator: new_spec})
+    )
     db.session.commit()
 
-    update_observer_status(room,sid)
+    update_observer_status(room, sid)
+
 
 def update_observer_status(room, sid):
     """
@@ -104,8 +128,11 @@ def update_observer_status(room, sid):
         this is used on inital login
         and when the user toggles the status
     """
-    listtmp = db.session.query(room_members).filter_by(room=room, member_id=sid).all()
-    #    select spectator, dm_room from room_members where room = room and member_id = sid
+    listtmp = (
+        db.session.query(room_members)
+        .filter_by(room=room, member_id=sid)
+        .all()
+        )
     print(listtmp)
     for record in listtmp:
         Spec = None
@@ -113,8 +140,8 @@ def update_observer_status(room, sid):
             Spec = "Spectator"
         else:
             Spec = "Player"
-    
         emit('observer_status', Spec, room=record.dm_room)
+
 
 @socketio.on("voted", namespace="/chat")
 @authenticated_only
@@ -122,20 +149,26 @@ def checkVote(message):
     room = session.get('room')
     update_room_idle(room)
     emit("status", {"msg": message["voteChoice"]}, room=room)
-    
+
 
 def update_room_idle(room):
-    # we may need to do something different here, expiring the key removes the data
+    # we may need to do something different here
+    # expiring the key removes the data
     # but people could still be in the room
     pass
 
+
 def send_userlist(room):
     # Get the mamber name from the room_members table filterd by the room
-    userlisttmp = db.session.query(room_members.member_name).filter_by(room=room).all()
+    userlisttmp = (
+        db.session.query(room_members.member_name)
+        .filter_by(room=room)
+        .all())
     # cleanup the results to display
     userlist = [value for value, in userlisttmp]
     print("Userlist - {}".format(userlist))
     emit('userlist', userlist, room=room)
 
-    # need to compare the sid's in the rooms table with the sids in the session table
+    # need to compare the sid's in the rooms table
+    # with the sids in the session table
     # and remove any folks from rooms who's sessions have expired

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,7 +1,11 @@
 from flask import session, redirect, url_for, render_template, request
 from . import main
 from .forms import LoginForm
+from flask_login import login_user
+import flask_login
 
+class User(flask_login.UserMixin):
+    pass
 
 @main.route('/', methods=['GET', 'POST'])
 def index():
@@ -10,6 +14,10 @@ def index():
     if form.validate_on_submit():
         session['name'] = form.name.data
         session['room'] = form.room.data
+
+        user = User()
+        user.id = form.name.data
+        login_user(user)
         # force session timeout set in login
         # session permaneny needs to be TRUE for the timeout to work
         session.permanent = True
@@ -26,6 +34,8 @@ def chat():
     the session."""
     name = session.get('name', '')
     room = session.get('room', '')
+    if room is None or name is None:
+        return redirect(url_for('.index'))
     if name == '' or room == '':
         return redirect(url_for('.index'))
     return render_template('chat.html', name=name, room=room)

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -4,8 +4,10 @@ from .forms import LoginForm
 from flask_login import login_user
 import flask_login
 
+
 class User(flask_login.UserMixin):
     pass
+
 
 @main.route('/', methods=['GET', 'POST'])
 def index():
@@ -39,4 +41,3 @@ def chat():
     if name == '' or room == '':
         return redirect(url_for('.index'))
     return render_template('chat.html', name=name, room=room)
-

--- a/app/models.py
+++ b/app/models.py
@@ -1,18 +1,21 @@
 ###############################
 # WARNING                     #
 ###############################
-# If you edit this file you will need to 
+# If you edit this file you will need to
 #  - reinitalize the database file (database.sqlite3)
 #    deleting and restarting should do it
 
 
-
 from . import db
+
 
 class room_members(db.Model):
     room = db.Column(db.String(255), primary_key=True)
     member_id = db.Column(db.String(255), primary_key=True)
     member_name = db.Column(db.String(255))
-    spectator = db.Column(db.Boolean())         # Are they playing or just hanging out
-    dm_room = db.Column(db.String(255))         # id used to send message directly to a player
 
+    # Are they playing or just hanging out
+    spectator = db.Column(db.Boolean())
+
+    # id used to send message directly to a player
+    dm_room = db.Column(db.String(255))


### PR DESCRIPTION
The session timeout was set to 5 minutes, that has been removed and it now has the default of 30 days.  This along with changes to check for a valid session, remove a number of exceptions that were being thrown when a user with an expired session attempted to interact with the room.